### PR TITLE
Convert into Terraform Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is intended for use as a module in another project. You would include it li
 // ... other resources
 
 module "ebs_backups" {
-  source = "github.com:nathanielks/ebs_snapshot_terraform"
+  source = "github.com:mivok/ebs_snapshot_terraform"
 }
 ```
 
@@ -29,7 +29,7 @@ It exposes the following variables:
 If you wanted to run a backup every hour:
 ```
 module "ebs_backups" {
-  source = "github.com:nathanielks/ebs_snapshot_terraform"
+  source = "github.com:mivok/ebs_snapshot_terraform"
 
   backups_schedule = "rate(1 hour)"
 }
@@ -38,7 +38,7 @@ module "ebs_backups" {
 If you wanted to use your own backup script:
 ```
 module "ebs_backups" {
-  source = "github.com:nathanielks/ebs_snapshot_terraform"
+  source = "github.com:mivok/ebs_snapshot_terraform"
 
   backups_zip = "${path.module}/backup.zip"
 }

--- a/README.md
+++ b/README.md
@@ -8,19 +8,41 @@ the code at
 
 ## Usage
 
-### Running terraform
+### Terraform Module
 
-Make sure you have an AWS API key set up for your account in
-`~/.aws/credentials`, then run:
+This is intended for use as a module in another project. You would include it like so:
+```
+// ... other resources
 
-    AWS_PROFILE=myprofile terraform plan
-    AWS_PROFILE=myprofile terraform apply
+module "ebs_backups" {
+  source = "github.com:nathanielks/ebs_snapshot_terraform"
+}
+```
 
-If you set up your credentials as the default profile, you can skip the
-`AWS_PROFILE` environment variable setting and just run `terraform
-plan`/`terraform apply` directly.
+It exposes the following variables:
 
-Once you have run terraform apply, commit the terraform state file.
+- `backups_schedule`: a `rate` or `cron` expression. Defaults to `cron(0 20 * * ? *)`. See [Schedule Expressions][schedule-expressions] for more info.
+- `janitor_schedule`: a `rate` or `cron` expression. Defaults to `cron(30 20 * * ? *)`. See [Schedule Expressions][schedule-expressions] for more info.
+- `backups_zip`: the filepath to the file to use as the scheduled backup Lambda function. Lambda functions uploaded via terraform need to be uploaded as a zip file.
+- `janitor_zip`: the filepath to the file to use as the janitor Lambda function. Lambda functions uploaded via terraform need to be uploaded as a zip file.
+
+If you wanted to run a backup every hour:
+```
+module "ebs_backups" {
+  source = "github.com:nathanielks/ebs_snapshot_terraform"
+
+  backups_schedule = "rate(1 hour)"
+}
+```
+
+If you wanted to use your own backup script:
+```
+module "ebs_backups" {
+  source = "github.com:nathanielks/ebs_snapshot_terraform"
+
+  backups_zip = "${path.module}/backup.zip"
+}
+```
 
 ### Configuring your instances to be backed up
 
@@ -30,8 +52,12 @@ By default, old backups will be removed after 7 days, to keep them longer, set
 another tag: `Retention = 14`, where 14 is the number of days you want to keep
 the backups for.
 
-## Updating the script
+## Contributing
+
+### Updating the script
 
 Lambda functions uploaded via terraform need to be uploaded as a zip file. To
 change the code, make your changes to the python code and then run `make`.
 This will create/update the zip files for terraform to re-upload.
+
+[schedule-expressions]: http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html

--- a/aws_provider.tf
+++ b/aws_provider.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = "us-east-1"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,17 @@
 # See https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
 # for how to write schedule expressions
-variable "ebs_snapshot_backups_schedule" {
+variable "backups_schedule" {
   default = "cron(0 20 * * ? *)"
 }
 
-variable "ebs_snapshot_janitor_schedule" {
+variable "janitor_schedule" {
   default = "cron(30 20 * * ? *)"
+}
+
+variable "backups_zip" {
+  default = ""
+}
+
+variable "janitor_zip" {
+  default = ""
 }


### PR DESCRIPTION
This PR converts `mivok/ebs_snapshot_terraform` into a terraform module for easy inclusion in projects. All one has to do is add the necessary tags to their instances and add the module to their terraform project:
```
module "ebs_backups" {
  source = "github.com:mivok/ebs_snapshot_terraform"
}
```